### PR TITLE
Run Action on Node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,5 +8,5 @@ inputs:
   time:
     description: 'A time period as ms or string (100, 10s, 1m)'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Node 12 deprecation warnings are being thrown when running this action. Updating the runner to use Node 16 will alleviate them.