### PR TITLE
update to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,5 +8,5 @@ inputs:
   time:
     description: 'A time period as ms or string (100, 10s, 1m)'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/package.json
+++ b/package.json
@@ -15,13 +15,13 @@
     "publish": false
   },
   "dependencies": {
-    "@actions/core": "^1.9.1",
-    "ms": "^2.1.2"
+    "@actions/core": "^1.10.1",
+    "ms": "^2.1.3"
   },
   "devDependencies": {
-    "@vercel/ncc": "^0.36.1",
-    "np": "^8.0.2",
-    "prettier-standard": "^15.0.1",
-    "standard": "^14.3.1"
+    "@vercel/ncc": "^0.38.0",
+    "np": "^9.0.0",
+    "prettier-standard": "^17.0.0",
+    "standard": "^17.0.0"
   }
 }


### PR DESCRIPTION
This PR updates the sleep-action to node-24 as [node-20 gets deprecated on action runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) in June 2026